### PR TITLE
Add Private-CaaS 2.15 release notes + minor fixes

### DIFF
--- a/content/en/docs/private-kubernetes/changelog/v2.15.0-elx1.md
+++ b/content/en/docs/private-kubernetes/changelog/v2.15.0-elx1.md
@@ -1,0 +1,49 @@
+---
+title: "Changelog for Kubernetes 1.19"
+description: "Changelog for Kubernetes 1.19"
+alwaysopen: true
+---
+
+## Versions
+
+* Kubernetes 1.19.7
+* Nginx-ingress: 0.43.0
+* Certmanager: 1.2.0
+
+## Major changes
+
+* New security groups are implemented where you can store all youre firewall rules. The new security groups will be persistent between upgrades and called `CLUSTERNAME-k8s-worker-customer` and `CLUSTERNAME-k8s-master-customer` (CLUSTERNAME will be replaced with actual cluster name).
+  With this change we will remove our previous default firewall rules that allowed public traffic to the Kubernetes cluster, this includes the following services:
+	- Master API (port 6443)
+	- Ingress (port 80 & 443)
+	- Nodeports (ports 30000 to 32676) 
+  
+  </br>
+  If you currently have any of the mentioned ports open you either need to add them to the new security groups (created during the upgrade) or mention this during the planning discussion and we will assist you with this. 
+  Please be aware that any rules added to the new security groups is not managed by us and you are responsible for them being up to date.
+
+## Deprecations
+
+* Ingress api `extensions/v1beta1` will be removed in kubernetes 1.22
+* RBAC api `rbac.authorization.k8s.io/v1alpha1` and `rbac.authorization.k8s.io/v1beta1` will be removed in kubernetes 1.20. The apis are replaced with `rbac.authorization.k8s.io/v1`.
+* The node label `beta.kubernetes.io/instance-type` will be rmeoved in an uppcomig release. Use `node.kubernetes.io/instance-type` instead.
+* Certmanager api `v1alpha2`, `v1alpha3` and `v1beta1` will be removed in a future release. We strongly recommend that you upgrade to the new `v1` api
+
+## Is downtime expected
+
+The upgrade drains (moving all workload from) one node at the time, patches that node and brings in back in the cluster. First after all deployments and statefulsets are running again we will continue on with the next node.
+
+## Known issues
+
+### Custom node taints and labels lost during upgrade
+
+All custom taints and labels on nodes are lost during upgrade.
+
+### Custom security groups will be lost during upgrade
+
+All custom security groups bound inside openstack will be detached during upgrade.
+
+### Snapshots is not working
+
+There is currently a limitation in the snapshot controller not making it topology aware.
+

--- a/content/en/docs/private-kubernetes/getting-started/requirements.md
+++ b/content/en/docs/private-kubernetes/getting-started/requirements.md
@@ -8,14 +8,13 @@ alwaysopen: true
 To get started you need certain tools in order to administrate your cluster and applications.
 
 * kubectl
-* helm (optional)
 * Knowledge of how Kubernetes works
 
 You also need a configuration file from us called `<yourcluster>-kubeconfig` and if you have access to multiple clusters, you can choose to combine your own `~/.kube/config` or set the environment variable `KUBECONFIG` which both kubectl and helm honors. We will be showing how you do the latter.
 
 > To maintain your own kubeconfig you can read more about the topic in Kubernetes official documentation:  [Configure Access to Multiple Clusters](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
 
-To install `kubectl` you can follow the official documentation here: [Install and Set Up kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/). And for `helm` you can follow their documentation: [Installing the Helm client](https://github.com/helm/helm/blob/master/docs/install.md#installing-the-helm-client)
+To install `kubectl` you can follow the official documentation here: [Install and Set Up kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/). 
 
 ## Verify access
 

--- a/content/en/docs/private-kubernetes/overview.md
+++ b/content/en/docs/private-kubernetes/overview.md
@@ -22,5 +22,3 @@ As Kubernetes runs on top of our high perfomant OpenStack platform, we integrate
 * Persistent Storage: When creating a *volume claim* Kubernetes creates a volume using *OpenStack Cinder* and then connects the volume on the node where your pod(s) gets scheduled. There's also support for having your storage encrypted thanks to our Fortanix [HSM and KMS solution for OpenStack](https://elastx.se/en/blog/check-out-our-customer-testimonial-for-fortanix-services).
 
 * Ingress Controller: We are combining *Nginx Ingress controller* with *Cert Manager*. So if you want, you can create an ingress to expose your web service. *Cert Manager* can help automate the creation of Let's Encrypt SSL certificates.
-
-* Metrics available: ELASTX Private Kubernetes is a managed service. We deploy *Prometheus* with *Alertmanager* and *Grafana* for us to monitor the well being of the cluster. But this also means you consume the metrics from this aswell, and setup your own Grafana with custom Dashboards.


### PR DESCRIPTION
* Add release note for Private CaaS 2.15 (kubernetes 1.19)
* Remove helm from Private CaaS requirements file
* Remove information regarding the Prometheus, Alertmanager and Grafana setup