### PR TITLE
adding affinity guide

### DIFF
--- a/content/en/docs/openstack-iaas/guides/affinity.md
+++ b/content/en/docs/openstack-iaas/guides/affinity.md
@@ -1,0 +1,21 @@
+---
+title: "Affinity Policy"
+description: "Guide for using Affinity Policies"
+weight: 1
+alwaysopen: true
+---
+## Overview
+This is a guide on how to make sure the a group of instances do not run on the same compute node. For example if you want to run a cluster of instances you do not want multiple instances to fail if a compute node fails.
+
+1. Create an anti affinity group.  
+```nova server-group-create testgroup anti-affinity```
+
+1. (Optional) Read out the affinity policies.  
+```nova server-group-list | grep -Ei "Policies|affinity"```
+
+1. Add the instance to the group when deploying.  
+```nova boot --image IMAGE_ID --flavor m1.small --hint group=SERVER_GROUP_UUID cluster-node-1 ```
+
+## Additional links
+This is relevant to the "Train" version of Openstack:
+https://docs.openstack.org/senlin/train/user/policy_types/affinity.html

--- a/content/en/docs/openstack-iaas/guides/affinity.md
+++ b/content/en/docs/openstack-iaas/guides/affinity.md
@@ -4,13 +4,15 @@ description: "Guide for using Affinity Policies"
 weight: 1
 alwaysopen: true
 ---
-
 ## Overview
-This is a guide on how to make sure the group of instances do not run on the same compute node. For example if you want to run a cluster of instances you do not want multiple instances to fail if a compute node fails.
+Here is how to avoid that groups of instances run on the same compute node. This can be relevant when configuring resilience.
 
 1. Create an anti affinity group.    
-Take note of the group UUID that is displayed when created. It will be used when deploying the instance soon.  
+Take note of the group UUID that is displayed when created. It is needed when deploying the instance.  
 ```openstack server group create --policy anti-affinity testgroup```  
+
+     https://docs.openstack.org/python-openstackclient/rocky/cli/command-objects/server-group.html
+
 
 1. (Optional) Read out the affinity policies.  
 ```openstack server group list | grep -Ei "Policies|affinity"```
@@ -18,10 +20,7 @@ Take note of the group UUID that is displayed when created. It will be used when
 1. Add the instance to the group when deploying.  
 ```openstack server create --image ubuntu-20.04-server-latest --flavor v1-small-1 --hint group=<server_group_uuid> test-instance```
 
+    https://docs.openstack.org/python-openstackclient/rocky/cli/command-objects/server.html
+
 ## Additional links
-This is relevant to the "Train" version of Openstack:
-https://docs.openstack.org/senlin/train/user/policy_types/affinity.html
-
-Info: https://docs.openstack.org/python-openstackclient/train/cli/command-objects/server-group.html
-
-Info: https://docs.openstack.org/python-openstackclient/train/cli/command-objects/server.html
+https://docs.openstack.org/senlin/rocky/user/policy_types/affinity.html

--- a/content/en/docs/openstack-iaas/guides/affinity.md
+++ b/content/en/docs/openstack-iaas/guides/affinity.md
@@ -4,18 +4,24 @@ description: "Guide for using Affinity Policies"
 weight: 1
 alwaysopen: true
 ---
-## Overview
-This is a guide on how to make sure the a group of instances do not run on the same compute node. For example if you want to run a cluster of instances you do not want multiple instances to fail if a compute node fails.
 
-1. Create an anti affinity group.  
-```nova server-group-create testgroup anti-affinity```
+## Overview
+This is a guide on how to make sure the group of instances do not run on the same compute node. For example if you want to run a cluster of instances you do not want multiple instances to fail if a compute node fails.
+
+1. Create an anti affinity group.    
+Take note of the group UUID that is displayed when created. It will be used when deploying the instance soon.  
+```openstack server group create --policy anti-affinity testgroup```  
 
 1. (Optional) Read out the affinity policies.  
-```nova server-group-list | grep -Ei "Policies|affinity"```
+```openstack server group list | grep -Ei "Policies|affinity"```
 
 1. Add the instance to the group when deploying.  
-```nova boot --image IMAGE_ID --flavor m1.small --hint group=SERVER_GROUP_UUID cluster-node-1 ```
+```openstack server create --image ubuntu-20.04-server-latest --flavor v1-small-1 --hint group=<server_group_uuid> test-instance```
 
 ## Additional links
 This is relevant to the "Train" version of Openstack:
 https://docs.openstack.org/senlin/train/user/policy_types/affinity.html
+
+Info: https://docs.openstack.org/python-openstackclient/train/cli/command-objects/server-group.html
+
+Info: https://docs.openstack.org/python-openstackclient/train/cli/command-objects/server.html


### PR DESCRIPTION
Migration of:
https://elastx.zendesk.com/knowledge/articles/214238046/en-us?brand_id=2236496

Adapted and tested commands, as the policy instruction seemed legacy and did not work.

Last command of setting up a VM is not fully tested, but is also not particularly verbose in initial version.