### PR TITLE
Revert dash removal on podSelector in NetworkPolicy

### DIFF
--- a/k8s/bases/elx-docs/networkpolicies.yaml
+++ b/k8s/bases/elx-docs/networkpolicies.yaml
@@ -14,7 +14,7 @@ spec:
     - namespaceSelector:
         matchLabels:
           app.kubernetes.io/name: ingress-nginx
-      podSelector:
+    - podSelector:
         matchLabels:
           app.kubernetes.io/name: ingress-nginx
 ---


### PR DESCRIPTION
Revert one change from cb011fa. The podSelector should still be a list item under the from parent.