### PR TITLE
Horizon invite member to project

### DIFF
--- a/content/en/docs/openstack-iaas/guides/adjutant.md
+++ b/content/en/docs/openstack-iaas/guides/adjutant.md
@@ -13,6 +13,10 @@ alwaysopen: true
 
 Users can be managed directly from the [management tab](https://ops.elastx.cloud/management/project_users/) in Horizon dashboard.
 
+To invite a new member to your project(s) go to "Management" -> "Access Control" -> "Project Users" in the menu, and then click "Invite User" on the right hand side. A popup will appear with a textbox where you can type the email of the new user. Below the textbox you can chose which roles (described below) to assign that user. Click "Invite" when done and an invite will be sent via email. 
+
+_Note: If the user doesn't have an OpenStack account with us already, they will have to follow the email instructions and sign up._
+
 There are a couple of roles that can be assigned to users inside of a project:
 
 - Load Balancer - Allow access to manage load balancers (Octavia).


### PR DESCRIPTION
Detailed instructions on how to invite new members to an OpenStack project from Horizon.

Source: https://github.com/elastx/team-cs/issues/126