### PR TITLE
Add changelog for Kubernetes 1.24 and update 1.23

### DIFF
--- a/content/en/docs/private-kubernetes/changelog/v2.19.1-elx1.md
+++ b/content/en/docs/private-kubernetes/changelog/v2.19.1-elx1.md
@@ -32,6 +32,10 @@ alwaysopen: true
 
 * The storage class `4k` will no longer be set-up due to it being deprecated in Openstack. [The full announcement can be found here.](https://docs.elastx.cloud/docs/openstack-iaas/announcement/#2022-06-13-reducing-openstack-volume-price-with-up-to-63-and-increasing-performance-with-up-to-50)
 
+
+## What happened to the metrics/monitoring node?
+
+Previously when creating new or upgrading clusters to Kubernetes 1.23 we added an extra node that handled monitoring. This node is no longer needed and all services have been converted to run inside the Kubernetes cluster. This means that clusters being upgraded or created from now on won't get an extra node added. Clusters that currently have the monitoring node will be migrated to the new setup within the upcoming weeks (The change is non-service affecting).
 ## Deprecations
 
 > Note that all deprecations will be removed in a future Kubernetes release. This does not mean you need to perform any changes right now. However, we recommend you to start migrating your applications in order to avoid issues in future releases.

--- a/content/en/docs/private-kubernetes/changelog/v2.20.0-elx1.md
+++ b/content/en/docs/private-kubernetes/changelog/v2.20.0-elx1.md
@@ -1,42 +1,25 @@
 ---
-title: "Changelog for Kubernetes 1.23"
-description: "Changelog for Kubernetes 1.23"
+title: "Changelog for Kubernetes 1.24"
+description: "Changelog for Kubernetes 1.24"
 alwaysopen: true
 ---
 
 ## Versions
 
-* Kubernetes 1.23.7
-* Nginx-ingress: 1.3.0
-* Certmanager: 1.9.1
+* Kubernetes 1.24.6
+* Nginx-ingress: 1.4.0
+* Certmanager: 1.10.0
 
 ## Major changes
 
-* A new storage class `v1-dynamic-40` is introduced and set as the default storage class. [All information about this storage class can be found here.](https://docs.elastx.cloud/docs/openstack-iaas/announcement/#new-volume-type-v1-dynamic-40)
-* Worker and control plane nodes now use `v1-c2-m8-d80` as their default flavor. [You can find a complete list of all available flavors here.](https://elastx.se/en/openstack/pricing)
-* All nodes will be migrated to the updated flavors during the upgrade. All new flavors will have the same specification however the flavor ID will be changed. This affects customers that use the `node.kubernetes.io/instance-type` label that can be located on nodes.
-* Control plane nodes will have their disk migrated from the deprecated `4k` storage class to `v1-dynamic-40`.
-* Starting from Kubernetes 1.23 we will require 3 control plane (masters) nodes.
-
-## Flavor mapping
-
-| Old flavor | New flavor |
-| ---------- | ---------- |
-| v1-standard-2 | v1-c2-m8-d80 |
-| v1-standard-4 | v1-c4-m16-d160 |
-| v1-standard-8 | v1-c8-m32-d320 |
-| v1-dedicated-8 | d1-c8-m58-d800 |
-| v2-dedicated-8 | d2-c8-m120-d1.6k |
-
-## Changes affecting new clusters:
-
-* The storage class `4k` will no longer be set-up due to it being deprecated in Openstack. [The full announcement can be found here.](https://docs.elastx.cloud/docs/openstack-iaas/announcement/#2022-06-13-reducing-openstack-volume-price-with-up-to-63-and-increasing-performance-with-up-to-50)
+* The `node-role.kubernetes.io/master=` label is removed from all control plane nodes, instead use the `node-role.kubernetes.io/control-plane=` label.
+* The taint `node-role.kubernetes.io/control-plane:NoSchedule` has been added to all control plane nodes.
 
 ## Deprecations
 
 > Note that all deprecations will be removed in a future Kubernetes release. This does not mean you need to perform any changes right now. However, we recommend you to start migrating your applications in order to avoid issues in future releases.
 
-* In kubernetes 1.25 the storage class `4k` will be removed from all clusters created prior to Kubernetes 1.23.
+* In Kubernetes 1.25 the storage class `4k` will be removed from all clusters. This only affects clusters created prior to Kubernetes 1.23. Instead use the v1-dynamic-40 which is the default storage class since Kubernetes 1.23.
 
 ### APIs removed in Kubernetes 1.25
 
@@ -48,6 +31,13 @@ More details can be found in [Kubernetes official documentation.](https://kubern
   * Event `events.k8s.io/v1beta1`. The new API `events.k8s.io/v1` was implemented in Kubernetes 1.19
   * PodDisruptionBudget `policy/v1beta1`. The new API `policy/v1` was implemented in Kubernetes 1.21
   * RuntimeClass `node.k8s.io/v1beta1`. The new API `node.k8s.io/v1` was implemented in Kubernetes 1.20
+
+### APIs removed in Kubernetes 1.26
+
+More details can be found in [Kubernetes official documentation.](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-26)
+
+  * Flow control resources `flowcontrol.apiserver.k8s.io/v1beta1`. The replacement `flowcontrol.apiserver.k8s.io/v1beta2` was implemented in Kubernetes 1.23
+  * HorizontalPodAutoscaler `autoscaling/v2beta2`. The replacement `autoscaling/v2` was introduced in Kubernetes 1.23
 
 ### Other noteworthy deprecations
 


### PR DESCRIPTION
Add changelog for Kubernetes 1.24 and update changelog for Kubernetes 1.23 where we remove the metric node requirement in favor of running everything in-cluster