### PR TITLE
Intendation of the pvc yaml example

### DIFF
--- a/content/en/docs/private-kubernetes/getting-started/persistent-volumes.md
+++ b/content/en/docs/private-kubernetes/getting-started/persistent-volumes.md
@@ -44,15 +44,15 @@ A quick example of how to create an unused 1Gi persistent volume claim named
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-name: example
+  name: example
 spec:
-accessModes:
-- ReadWriteOnce
-volumeMode: Filesystem
-resources:
-requests:
-storage: 1Gi
-storageClassName: 16k
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: 16k
 ```
 
 ```bash


### PR DESCRIPTION
The example yaml file for a pvc did not have any indentation which made it harder than necessary to read, edited it to have proper indentation