### PR TITLE
Update to Hugo 0.110.0, Docsy 0.6.0

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -22,17 +22,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     container:
-      image: quay.io/elastx/ci-hugo:v0.99.1
+      image: quay.io/elastx/ci-hugo:v0.110.0
     steps:
       - uses: actions/checkout@v3
       - name: Build content
         run: |
-          export NODE_PATH=$NODE_PATH:`npm root -g`
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git submodule update --init --recursive
           HUGO_ENV=production hugo -v
       - name: Test webpage
-        run: htmlproofer public --allow-hash-href --check-html --empty-alt-ignore --disable-external --file-ignore /revealjs/,/404.html/
+        run: htmltest -c htmltest.yml
       - name: Save config and logs artifact
         uses: actions/upload-artifact@v3
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .vscode
 test
 resources
+tmp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,1 @@
 
-[submodule "themes/docsy"]
-	path = themes/docsy
-	url = https://github.com/google/docsy.git

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/elastx/elx-docs
+
+go 1.20
+
+require github.com/google/docsy v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.6.0 h1:43bVF18t2JihAamelQjjGzx1vO2ljCilVrBgetCA8oI=
+github.com/google/docsy v0.6.0/go.mod h1:VKKLqD8PQ7AglJc98yBorATfW7GrNVsn0kGXVYF6G+M=
+github.com/google/docsy/dependencies v0.6.0/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
+github.com/twbs/bootstrap v4.6.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/htmltest.yml
+++ b/htmltest.yml
@@ -1,0 +1,7 @@
+---
+DirectoryPath: public
+CheckExternal: false
+IgnoreAltEmpty: true
+IgnoreAltMissing: true
+IgnoreEmptyHref: true
+IgnoreInternalEmptyHash: true

--- a/hugo.toml
+++ b/hugo.toml
@@ -6,7 +6,7 @@ title = "Documentation"
 enableRobotsTXT = true
 
 # Hugo allows theme composition (and inheritance). The precedence is from left to right.
-theme = ["docsy"]
+theme = ["github.com/google/docsy", "github.com/google/docsy/dependencies"]
 
 # Will give values to .Lastmod etc.
 enableGitInfo = true

--- a/test-locally.sh
+++ b/test-locally.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env sh
 
 echo "Building and serving web content on http://localhost:1313/docs (Ctrl + C to exit)"
-git submodule update --init --recursive
-docker run --rm -v $(pwd):/root/project/ -p 1313:1313 -e HUGO_ENV=production quay.io/elastx/ci-hugo:v0.99.1 hugo server --bind 0.0.0.0
+docker run --rm -v $(pwd):/root/project/ -p 1313:1313 -e HUGO_ENV=production quay.io/elastx/ci-hugo:v0.110.0 hugo server --bind 0.0.0.0


### PR DESCRIPTION
This PR updates to Hugo 0.110.0 and Docsy 0.6.0. We are no longer using git submodules in favour of Hugo Modules. htmlproofer has been replaced with htmltest for site testing.