### PR TITLE
Added information about pv type hostPath

### DIFF
--- a/content/en/docs/private-kubernetes/getting-started/persistent-volumes.md
+++ b/content/en/docs/private-kubernetes/getting-started/persistent-volumes.md
@@ -74,6 +74,10 @@ All volumes are encrypted at rest in hardware. Volumes created by storage
 classes ending with *enc* are also software encrypted using a per volume
 encryption key. This provides increased security but has an impact on performance.
 
+## Type hostPath
+
+A PV of type `hostPath` only emulates a network-attached storage and is in reality a local file/dir on the specific node instead of an actual external volume. It is as such not recommended to use if your pods should be able to run on different nodes in your cluster.
+
 # Known issues
 
 ## Resizing encrypted volumes

--- a/content/en/docs/private-kubernetes/getting-started/persistent-volumes.md
+++ b/content/en/docs/private-kubernetes/getting-started/persistent-volumes.md
@@ -76,7 +76,9 @@ encryption key. This provides increased security but has an impact on performanc
 
 ## Type hostPath
 
-A PV of type `hostPath` only emulates a network-attached storage and is in reality a local file/dir on the specific node instead of an actual external volume. It is as such not recommended to use if your pods should be able to run on different nodes in your cluster.
+A PV of type hostPath is in reality a local file/dir on the specific node instead of an actual external volume. This might cause several undesired behaviors.
+The PV becomes tied to a specific node. During cluster maintenance/upgrades the workload will be moved off each node in turn. When a pod is restarted on another node, it will still expect to find data at its PV with type hostPath, but since that PV is tied to the previous node, it will not find the data its looking for.
+In order for the clusters workload to remain resilient in the event of a node failure, or during maintenance/upgrades, hostPath PV's needs to be avoided.
 
 # Known issues
 


### PR DESCRIPTION
Added a recommendation to not run a PV of type hostPath if they want to actually use an external volume that can be used by different nodes. Comes from ticket 11657 where the customer's pod was evicted to a different node during a planned maintenance window and thought their data was lost.