### PR TITLE
updated persistent volume documentation:

### DIFF
--- a/content/en/docs/private-kubernetes/getting-started/persistent-volumes.md
+++ b/content/en/docs/private-kubernetes/getting-started/persistent-volumes.md
@@ -10,9 +10,15 @@ Cinder](https://docs.openstack.org/cinder/train/). Volumes are dynamically
 provisioned by [Kubernetes Cloud Provider
 OpenStack](https://github.com/kubernetes/cloud-provider-openstack/).
 
-# Storage classes
+## Storage classes 
 
-This is the current list of storage classes provided.
+`8k` refers to 8000 IOPS.
+
+> See our [pricing page](https://elastx.se/en/openstack/pricing)  under the table *Storage* to calculate your costs.
+
+### Kubernetes version < 1.22
+
+This is the list of storage classes provided in clusters of version <1.22.
 
 ```bash
 $ kubectl get storageclasses
@@ -21,14 +27,20 @@ NAME           PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE     
 4k (default)   cinder.csi.openstack.org   Delete          WaitForFirstConsumer   true                   167d
 8k             cinder.csi.openstack.org   Delete          WaitForFirstConsumer   true                   167d
 ```
+### Kubernetes version > 1.23
+This is the list of storage classes provided in clusters of version > 1.23.
 
-`4k` is short for 4000 IOPS and is the default storage class used when none is
-specified.
+```bash
+$ kubectl get storageclasses
+NAME                       PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+16k                        cinder.csi.openstack.org   Delete          WaitForFirstConsumer   true                   167d
+8k                         cinder.csi.openstack.org   Delete          WaitForFirstConsumer   true                   167d
+v1-dynamic-40 (default)    cinder.csi.openstack.org   Delete          WaitForFirstConsumer   true                   167d
+```
 
-> See our [pricing page](https://elastx.se/en/openstack/pricing)  under the table *Storage* to calculate your costs.
 
 
-# Example
+### Example of PersistentVolumeClaim
 
 A quick example of how to create an unused 1Gi persistent volume claim named
 *example*:
@@ -54,25 +66,25 @@ NAME      STATUS   VOLUME                                     CAPACITY   ACCESS 
 example   Bound    pvc-f8b1dc7f-db84-11e8-bda5-fa163e3803b4   1Gi        RWO            16k            18s
 ```
 
-# Good to know
+## Good to know
 
-## Cross mounting of volumes between nodes
+### Cross mounting of volumes between nodes
 
 Cross mounting of volumes is not supported! That is a volume can only be mounted
 by a node residing in the same availability zone as the volume. Plan
 accordingly for ensured high availability!
 
-## Limit of 25 volumes per node
+### Limit of 25 volumes per node
 
 There is a hard limitation of 25 volumes per node, including root volume. In case >20 volumes are required per node, consider adding additional worker nodes.
 
-## Encryption
+### Encryption
 
 All volumes are encrypted at rest in hardware.
 
-# Known issues
+## Known issues
 
-## Resizing encrypted volumes
+### Resizing encrypted volumes
 
 Legacy: encrypted volumes do not resize properly, please contact our support if you wish
 to resize such a volume.

--- a/content/en/docs/private-kubernetes/getting-started/persistent-volumes.md
+++ b/content/en/docs/private-kubernetes/getting-started/persistent-volumes.md
@@ -16,24 +16,19 @@ This is the current list of storage classes provided.
 
 ```bash
 $ kubectl get storageclasses
-NAME           PROVISIONER            AGE
-16k            kubernetes.io/cinder   5d
-16kenc         kubernetes.io/cinder   5d
-4k (default)   kubernetes.io/cinder   5d
-4kenc          kubernetes.io/cinder   5d
-8k             kubernetes.io/cinder   5d
-8kenc          kubernetes.io/cinder   5d
+NAME           PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+16k            cinder.csi.openstack.org   Delete          WaitForFirstConsumer   true                   167d
+4k (default)   cinder.csi.openstack.org   Delete          WaitForFirstConsumer   true                   167d
+8k             cinder.csi.openstack.org   Delete          WaitForFirstConsumer   true                   167d
 ```
 
 `4k` is short for 4000 IOPS and is the default storage class used when none is
-specified. Classes ending with `enc` are encrypted by a per volume encryption
-key. Hence, 16kenc creates encrypted volumes suited for 16000 IOPS.
+specified.
 
 > NOTE: The software encrypted volumes will soon be deprecated since all volume
 > storage is already encrypted in hardware.
 
-> See our [pricing page](https://elastx.se/en/pricing/)  under the heading *Pricing
-> OpenStack* in the table *Storage* to calculate your costs.
+> See our [pricing page](https://elastx.se/en/openstack/pricing)  under the table *Storage* to calculate your costs.
 
 # Example
 
@@ -62,21 +57,23 @@ example   Bound    pvc-f8b1dc7f-db84-11e8-bda5-fa163e3803b4   1Gi        RWO    
 ```
 
 # Good to know
-## Cross mounting of volumes
+## Cross mounting of volumes between nodes
 
 Cross mounting of volumes is not supported! That is a volume can only be mounted
 by a node residing in the same availability zone as the volume. Plan
 accordingly for ensured high availability!
 
-## Encrypted volumes
+## Limit of 25 volumes per node
 
-All volumes are encrypted at rest in hardware. Volumes created by storage
-classes ending with *enc* are also software encrypted using a per volume
-encryption key. This provides increased security but has an impact on performance.
+There is a hard limitation of 25 volumes per node, including root volume. In case >20 volumes are required, consider adding additional worker nodes.
+
+## Encryption
+
+All volumes are encrypted at rest in hardware.
 
 # Known issues
 
 ## Resizing encrypted volumes
 
-Encrypted volumes do not resize properly, please contact our support if you wish
+Legacy: encrypted volumes do not resize properly, please contact our support if you wish
 to resize such a volume.

--- a/content/en/docs/private-kubernetes/getting-started/persistent-volumes.md
+++ b/content/en/docs/private-kubernetes/getting-started/persistent-volumes.md
@@ -25,10 +25,8 @@ NAME           PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE     
 `4k` is short for 4000 IOPS and is the default storage class used when none is
 specified.
 
-> NOTE: The software encrypted volumes will soon be deprecated since all volume
-> storage is already encrypted in hardware.
-
 > See our [pricing page](https://elastx.se/en/openstack/pricing)  under the table *Storage* to calculate your costs.
+
 
 # Example
 
@@ -57,6 +55,7 @@ example   Bound    pvc-f8b1dc7f-db84-11e8-bda5-fa163e3803b4   1Gi        RWO    
 ```
 
 # Good to know
+
 ## Cross mounting of volumes between nodes
 
 Cross mounting of volumes is not supported! That is a volume can only be mounted
@@ -65,7 +64,7 @@ accordingly for ensured high availability!
 
 ## Limit of 25 volumes per node
 
-There is a hard limitation of 25 volumes per node, including root volume. In case >20 volumes are required, consider adding additional worker nodes.
+There is a hard limitation of 25 volumes per node, including root volume. In case >20 volumes are required per node, consider adding additional worker nodes.
 
 ## Encryption
 


### PR DESCRIPTION
* storage classes updated
* shaved off encrypted volumes references (saved legacy note)
* added section on limitations of volumes per node
* updated link to pricing
* minor wording