### PR TITLE
Changed version train to ussuri in the overview

### DIFF
--- a/content/en/docs/openstack-iaas/overview.md
+++ b/content/en/docs/openstack-iaas/overview.md
@@ -7,7 +7,7 @@ alwaysopen: true
 
 *ELASTX OpenStack IaaS* consists of a fully redundant installation spread over three different physical locations (openstack availability zones) in Stockholm, Sweden. Managed and monitored by us 24x7. You also have access to our support at any time.
 
-The current setup is based on [the OpenStack version Train](https://docs.openstack.org/train/user/).
+The current setup is based on [the OpenStack version Ussuri](https://docs.openstack.org/ussuri/user/).
 
 ![Overview of OpenStack IaaS data centers](/img/dc-1.png)
 


### PR DESCRIPTION
Fixed to the correct version, was showing train instead of ussuri.