### PR TITLE
Updated link OpenStack train docs to ussuri

### DIFF
--- a/content/en/docs/openstack-iaas/guides/volume_retype.md
+++ b/content/en/docs/openstack-iaas/guides/volume_retype.md
@@ -12,7 +12,8 @@ This guide will help you getting started with changing volume type in OpenStack'
 > Note: For volumes with -enc suffix it is required to work with the volume in detached mode
 
 In this example, we will use a detached volume with the type ```16k-IOPS-enc```.
-Get more information about the [OpenStack command-line client](https://docs.openstack.org/python-openstackclient/train/).
+
+Get more information about the [OpenStack command-line client](https://docs.openstack.org/python-openstackclient/ussuri/).
 
 ## Volume retype from Horizon
 


### PR DESCRIPTION
Updated link OpenStack train docs to ussuri for the Volume Retype guide. Also added another line break in between to separate the two rows a bit - they currently end up on the same line in the documentation.