### PR TITLE
Replace ussuri with wallaby for relevant documentation

### DIFF
--- a/content/en/docs/kubernetes/guides/loadbalancer.md
+++ b/content/en/docs/kubernetes/guides/loadbalancer.md
@@ -6,7 +6,7 @@ alwaysopen: true
 ---
 
 Load balancers in our Elastx Kubernetes CaaS service are provided by [OpenStack
-Octavia](https://docs.openstack.org/octavia/ussuri/reference/introduction.html)
+Octavia](https://docs.openstack.org/octavia/wallaby/reference/introduction.html)
 in collaboration with the [Kubernetes Cloud Provider
 OpenStack](https://github.com/kubernetes/cloud-provider-openstack). This article
 will introduce some of the basics of how to use services of *service* type
@@ -198,7 +198,7 @@ project or contact our support:
 
 * [Kubernetes Cloud Provider
   OpenStack](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#service-annotations)
-* [OpenStack Octavia](https://docs.openstack.org/octavia/ussuri/user/index.html)
+* [OpenStack Octavia](https://docs.openstack.org/octavia/wallaby/user/index.html)
 
 ## Good to know
 

--- a/content/en/docs/kubernetes/guides/persistent-volumes.md
+++ b/content/en/docs/kubernetes/guides/persistent-volumes.md
@@ -6,7 +6,7 @@ alwaysopen: true
 ---
 
 Persistent volumes in our Elastx Kubernetes CaaS service are provided by [OpenStack
-Cinder](https://docs.openstack.org/cinder/ussuri/). Volumes are dynamically
+Cinder](https://docs.openstack.org/cinder/wallaby/). Volumes are dynamically
 provisioned by [Kubernetes Cloud Provider
 OpenStack](https://github.com/kubernetes/cloud-provider-openstack/).
 

--- a/content/en/docs/openstack-iaas/guides/swift_getting_started.md
+++ b/content/en/docs/openstack-iaas/guides/swift_getting_started.md
@@ -152,6 +152,6 @@ Select the down arrow next to Download for the object you want to inspect and ch
 
 ## Further reading
 - Swift has an s3 compatible API for applications that don't support the Swift API. You can read more about how to configure Swift for s3cmd <a href="https://docs.elastx.cloud/docs/openstack-iaas/guides/s3_compatibility/">here</a>.  
- - You can find an S3/Swift REST API comparison matrix here at the <a href="https://docs.openstack.org/swift/ussuri/s3_compat.html">OpenStacks documentation</a>.  
- - If you want to use more advanced features, please see the <a href="https://docs.openstack.org/python-swiftclient/ussuri/cli/index.html">OpenStacks documentation for Swift</a>.  
+ - You can find an S3/Swift REST API comparison matrix here at the <a href="https://docs.openstack.org/swift/wallaby/s3_compat.html">OpenStacks documentation</a>.  
+ - If you want to use more advanced features, please see the <a href="https://docs.openstack.org/python-swiftclient/wallaby/cli/index.html">OpenStacks documentation for Swift</a>.  
  - Rclone is a good choice if you need more advanced functions while using Swift. You can read more about Rclone's support for Swift <a href="https://rclone.org/">here</a>.

--- a/content/en/docs/openstack-iaas/guides/volume_retype.md
+++ b/content/en/docs/openstack-iaas/guides/volume_retype.md
@@ -16,7 +16,7 @@ Either shut down your server or unmount the volume in your operating system befo
 
 In this example, we will use a detached volume with the type ```16k-IOPS-enc```.
 
-Get more information about the [OpenStack command-line client](https://docs.openstack.org/python-openstackclient/ussuri/).
+Get more information about the [OpenStack command-line client](https://docs.openstack.org/python-openstackclient/wallaby/).
 
 ## Volume retype from Horizon
 

--- a/content/en/docs/openstack-iaas/overview.md
+++ b/content/en/docs/openstack-iaas/overview.md
@@ -21,7 +21,7 @@ Our OpenStack environment currently runs the following services:
 - Heat - Orchestration service
 - Horizon - Dashboard
 - Glance - Image store. We provide images for the most popular operating systems. All Linux images except CentOS are unmodified from the official vendor cloud image. For CentOS we have changed out xfs file system to ext4 for stability reasons. You can find source code for our CentOS build process [here](https://github.com/elastx/centos-cloudimg).
-- Barbican - Secret store service which is powered by physical HSM appliances by Fortanix [HSM and KMS solution for OpenStack](https://elastx.se/en/blog/check-out-our-customer-testimonial-for-fortanix-services)
+- Barbican - Secret store service which is powered by physical HSM appliances
 - Octavia - Load balancer service, barbican integration for SSL termination
 - Cinder - Block storage with SSD based block storage and guaranteed IOPS reservations which is integrated with Barbican for optional encrypted volumes.
 - Swift - Object storage

--- a/content/en/docs/openstack-iaas/overview.md
+++ b/content/en/docs/openstack-iaas/overview.md
@@ -7,7 +7,7 @@ alwaysopen: true
 
 *ELASTX OpenStack IaaS* consists of a fully redundant installation spread over three different physical locations (openstack availability zones) in Stockholm, Sweden. Managed and monitored by us 24x7. You also have access to our support at any time.
 
-The current setup is based on [the OpenStack version Ussuri](https://docs.openstack.org/wallaby/user/).
+The current setup is based on [the OpenStack version Wallaby](https://docs.openstack.org/wallaby/user/).
 
 ![Overview of OpenStack IaaS data centers](/img/dc-1.png)
 

--- a/content/en/docs/openstack-iaas/overview.md
+++ b/content/en/docs/openstack-iaas/overview.md
@@ -7,7 +7,7 @@ alwaysopen: true
 
 *ELASTX OpenStack IaaS* consists of a fully redundant installation spread over three different physical locations (openstack availability zones) in Stockholm, Sweden. Managed and monitored by us 24x7. You also have access to our support at any time.
 
-The current setup is based on [the OpenStack version Ussuri](https://docs.openstack.org/ussuri/user/).
+The current setup is based on [the OpenStack version Ussuri](https://docs.openstack.org/wallaby/user/).
 
 ![Overview of OpenStack IaaS data centers](/img/dc-1.png)
 


### PR DESCRIPTION
To make the documentation in line with our current running version. 